### PR TITLE
Expose sort and fields parameters to basic search endpoint

### DIFF
--- a/server/api/archive.py
+++ b/server/api/archive.py
@@ -204,7 +204,7 @@ def get_arcade_games(query=None, page=1, limit=1000):
         'emulator:*' + ((' AND %s' % query) if query else '')
     return search(q, page=page, limit=limit, sort="sort%5B%5D=downloads+desc")
 
-def search(query, page=1, limit=100, security=True, sort=None):
+def search(query, page=1, limit=100, security=True, sort=None, fields=None):
     if not query:
         raise ValueError("GET query parameters 'q' required")
 
@@ -212,12 +212,13 @@ def search(query, page=1, limit=100, security=True, sort=None):
         raise MaxLimitException("Limit may not exceed 1000.")
 
     sort = sort or 'sort%5B%5D=date+asc&sort%5B%5D=createdate'
+    fields = fields or 'identifier,title'
     return requests.get(
         ADVANCED_SEARCH + sort,
         params={'q': query,
                 'rows': limit,
                 'page': page,
-                'fl[]': 'identifier,title',
+                'fl[]': fields,
                 'output': 'json',
             }).json()
 

--- a/server/views/apis/v1/search.py
+++ b/server/views/apis/v1/search.py
@@ -25,7 +25,9 @@ class Search(MethodView):
         query = i.get('q', '')
         limit = i.get('limit', 50)
         page = i.get('page', 1)
-        return search(query, page=page, limit=limit)
+        sort = i.get('sort', None)
+        fields = i.get('fields', None)
+        return search(query, page=page, limit=limit, sort=sort, fields=fields)
 
 
 class FulltextSearch(MethodView):


### PR DESCRIPTION
Doesn't change existing/default behavior, but allows the sort and fields to be specified for searches. I'm opening this in the hopes you can deploy it to api.archivelab.org, as that service has CORS set so it can be used programmatically, while archive.org/advancedsearch.php doesn't yet.

Please let me know if you have any questions or if there's anything else I can do to help get this changed (I'd also be happy if you can just add CORS to the main Advanced Search service, but figure this may be an easier change). Thanks!